### PR TITLE
feat: Add smart chat titles

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ import uuid
 from rerankers import Reranker
 from langsmith import traceable, Client
 load_dotenv()
-from pravah.llm import completion_llm
+from pravah.llm import completion_llm, generate_chat_title
 from pravah.prompts import generate_prompt_template, query_rewriter, extract_rewritten_prompt
 from pravah.retrieval import RetrievalEngine, LiteLLMEmbeddingClient
 from pravah.search import search_query, get_text_from_url, search_query_brave, search_query_duckduckgo
@@ -173,15 +173,20 @@ def setup_config_and_check_api_keys():
 
 def create_tables(conn):
     # Create tables without explicit transaction management
-    conn.execute("CREATE TABLE IF NOT EXISTS chat_history (conversation_uuid UUID PRIMARY KEY, user_input TEXT, response TEXT)")
+    conn.execute("CREATE TABLE IF NOT EXISTS chat_history (conversation_uuid UUID PRIMARY KEY, user_input TEXT, response TEXT, title TEXT)")
+    # Check if title column exists in chat_history and add it if not
+    try:
+        conn.execute("ALTER TABLE chat_history ADD COLUMN title TEXT")
+    except:
+        pass
     conn.execute("CREATE TABLE IF NOT EXISTS search_results (conversation_uuid UUID, search_result JSON, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
     conn.execute("CREATE TABLE IF NOT EXISTS fetched_texts (url TEXT PRIMARY KEY, text TEXT)")
     conn.execute("CREATE TABLE IF NOT EXISTS retrieved_chunks (conversation_uuid UUID, search_type TEXT, chunk TEXT, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
     conn.execute("CREATE TABLE IF NOT EXISTS re_written_prompt (conversation_uuid UUID, re_written_prompt TEXT, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
 
-def save_to_duckdb(conn, conversation_uuid, prompt, full_response, search_results, texts, urls, context_keyword, context_reranker, re_written_prompt):
+def save_to_duckdb(conn, conversation_uuid, prompt, full_response, search_results, texts, urls, context_keyword, context_reranker, re_written_prompt, title):
     # Save data without explicit transaction management
-    conn.execute("INSERT INTO chat_history (conversation_uuid, user_input, response) VALUES (?, ?, ?)", (conversation_uuid, prompt, full_response))
+    conn.execute("INSERT INTO chat_history (conversation_uuid, user_input, response, title) VALUES (?, ?, ?, ?)", (conversation_uuid, prompt, full_response, title))
     # Save search results to DuckDB
     conn.execute("INSERT INTO search_results (conversation_uuid, search_result) VALUES (?, ?)", (conversation_uuid, search_results))
     # Save fetched texts to DuckDB
@@ -403,8 +408,11 @@ def main():
         st.session_state.messages.append({"role": "assistant", "content": full_response})
         st.session_state.previous_prompt = re_written_prompt
         
+        # Generate Title
+        title = generate_chat_title(prompt, full_response, model=config.rewrite_model, temperature=0.5)
+
         with duckdb.connect(database='pravah.db') as conn:  
-            save_to_duckdb(conn, conversation_uuid, prompt, full_response, search_results, texts, urls, context_keyword, context_reranker, re_written_prompt)
+            save_to_duckdb(conn, conversation_uuid, prompt, full_response, search_results, texts, urls, context_keyword, context_reranker, re_written_prompt, title)
 
 
         main_run.end(outputs={"final_output": full_response})  # Ensure the RunTree is properly ended
@@ -412,12 +420,25 @@ def main():
     # Right-side panel for visualizing and bringing history back
     st.sidebar.header("Visualize and Use History")
     with duckdb.connect(database='pravah.db') as conn:  
-        chat_history = conn.execute("SELECT user_input, response FROM chat_history").fetchall()
-    previous_queries = [f"{chat[0]}" for chat in chat_history]
-    selected_history = st.sidebar.selectbox("Select a history to use", previous_queries)
+        chat_history = conn.execute("SELECT conversation_uuid, user_input, title FROM chat_history").fetchall()
+
+    chat_options = {str(chat[0]): (chat[1], chat[2]) for chat in chat_history}
+
+    def get_display_name(uuid_str):
+        item = chat_options.get(uuid_str)
+        if not item:
+            return uuid_str
+        title = item[1]
+        user_input = item[0]
+        if title and title.strip():
+            return title
+        return user_input[:50] + "..." if len(user_input) > 50 else user_input
+
+    selected_uuid = st.sidebar.selectbox("Select a history to use", list(chat_options.keys()), format_func=get_display_name)
+
     if st.sidebar.button("Use Selected History"):
         with duckdb.connect(database='pravah.db') as conn:  
-            selected_chat = conn.execute("SELECT * FROM chat_history WHERE user_input = ?", (selected_history,)).fetchone()
+            selected_chat = conn.execute("SELECT * FROM chat_history WHERE conversation_uuid = ?", (selected_uuid,)).fetchone()
         st.session_state.current_context = selected_chat
         st.session_state.messages.append({"role": "user", "content": selected_chat[1]})
         st.session_state.messages.append({"role": "assistant", "content": selected_chat[2]})

--- a/app.py
+++ b/app.py
@@ -180,11 +180,11 @@ def setup_config_and_check_api_keys():
 def create_tables(conn):
     # Create tables without explicit transaction management
     conn.execute("CREATE TABLE IF NOT EXISTS chat_history (conversation_uuid UUID PRIMARY KEY, user_input TEXT, response TEXT, title TEXT)")
-    # Check if title column exists in chat_history and add it if not
+    # Migration: add title column for existing databases that lack it
     try:
         conn.execute("ALTER TABLE chat_history ADD COLUMN title TEXT")
-    except:
-        pass
+    except Exception:
+        pass  # Column already exists
     conn.execute("CREATE TABLE IF NOT EXISTS search_results (conversation_uuid UUID, search_result JSON, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
     conn.execute("CREATE TABLE IF NOT EXISTS fetched_texts (url TEXT PRIMARY KEY, text TEXT)")
     conn.execute("CREATE TABLE IF NOT EXISTS retrieved_chunks (conversation_uuid UUID, search_type TEXT, chunk TEXT, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
@@ -442,15 +442,18 @@ def main():
 
     selected_uuid = st.sidebar.selectbox("Select a history to use", list(chat_options.keys()), format_func=get_display_name)
 
-    if st.sidebar.button("Use Selected History"):
-        with duckdb.connect(database='pravah.db') as conn:  
-            selected_chat = conn.execute("SELECT * FROM chat_history WHERE conversation_uuid = ?", (selected_uuid,)).fetchone()
-        st.session_state.current_context = selected_chat
-        st.session_state.messages.append({"role": "user", "content": selected_chat[1]})
-        st.session_state.messages.append({"role": "assistant", "content": selected_chat[2]})
-        st.session_state.previous_prompt = selected_chat[1]
-        st.rerun()
-        previous_prompt = selected_chat[1]
+    if st.sidebar.button("Use Selected History") and selected_uuid:
+        with duckdb.connect(database='pravah.db') as conn:
+            selected_chat = conn.execute(
+                "SELECT user_input, response FROM chat_history WHERE conversation_uuid = ?",
+                (selected_uuid,)
+            ).fetchone()
+        if selected_chat:
+            st.session_state.current_context = selected_chat
+            st.session_state.messages.append({"role": "user", "content": selected_chat[0]})
+            st.session_state.messages.append({"role": "assistant", "content": selected_chat[1]})
+            st.session_state.previous_prompt = selected_chat[0]
+            st.rerun()
 
 if __name__ == "__main__":
     main()

--- a/app.py
+++ b/app.py
@@ -33,6 +33,8 @@ class Config:
     rerank_limit: int = 10
     rewrite_model: str = 'groq/llama-3.1-8b-instant'
     rewrite_model_temperature: float = 0.1
+    title_model: str = 'groq/llama-3.1-8b-instant'
+    title_model_temperature: float = 0.1
     search_type: str = 'default' # or jina
     markdown: bool = True
     search_engine: str = 'tvly'
@@ -106,8 +108,8 @@ def check_api_keys(config):
     elif config.search_engine == 'brave':
         required_keys.append('BRAVE_API_KEY')
 
-    # Check API keys for both model and rewrite_model
-    for model in [config.model, config.rewrite_model]:
+    # Check API keys for both model, rewrite_model and title_model
+    for model in [config.model, config.rewrite_model, config.title_model]:
         key = check_model_key(model)
         if key:
             required_keys.append(key)
@@ -162,6 +164,10 @@ def setup_config_and_check_api_keys():
     with st.sidebar.expander("Rewrite Configuration", expanded=False):
         config.rewrite_model = st.text_input("Rewrite Model", config.rewrite_model, key='rewrite_model_input')
         config.rewrite_model_temperature = st.slider("Rewrite Model Temperature", 0.0, 1.0, config.rewrite_model_temperature, key='rewrite_model_temperature_slider')
+
+    with st.sidebar.expander("Title Configuration", expanded=False):
+        config.title_model = st.text_input("Title Model", config.title_model, key='title_model_input')
+        config.title_model_temperature = st.slider("Title Model Temperature", 0.0, 1.0, config.title_model_temperature, key='title_model_temperature_slider')
 
     with st.sidebar.expander("Reranker Configuration", expanded=False):
         config.reranker = st.selectbox("Reranker", ["cohere", "flashrank"], key='reranker_select')
@@ -409,7 +415,7 @@ def main():
         st.session_state.previous_prompt = re_written_prompt
         
         # Generate Title
-        title = generate_chat_title(prompt, full_response, model=config.rewrite_model, temperature=0.5)
+        title = generate_chat_title(prompt, full_response, model=config.title_model, temperature=config.title_model_temperature)
 
         with duckdb.connect(database='pravah.db') as conn:  
             save_to_duckdb(conn, conversation_uuid, prompt, full_response, search_results, texts, urls, context_keyword, context_reranker, re_written_prompt, title)

--- a/app.py
+++ b/app.py
@@ -183,7 +183,7 @@ def create_tables(conn):
     # Migration: add title column for existing databases that lack it
     try:
         conn.execute("ALTER TABLE chat_history ADD COLUMN title TEXT")
-    except Exception:
+    except duckdb.CatalogException:
         pass  # Column already exists
     conn.execute("CREATE TABLE IF NOT EXISTS search_results (conversation_uuid UUID, search_result JSON, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
     conn.execute("CREATE TABLE IF NOT EXISTS fetched_texts (url TEXT PRIMARY KEY, text TEXT)")
@@ -426,7 +426,7 @@ def main():
     # Right-side panel for visualizing and bringing history back
     st.sidebar.header("Visualize and Use History")
     with duckdb.connect(database='pravah.db') as conn:  
-        chat_history = conn.execute("SELECT conversation_uuid, user_input, title FROM chat_history").fetchall()
+        chat_history = conn.execute("SELECT conversation_uuid, user_input, title FROM chat_history ORDER BY rowid DESC").fetchall()
 
     chat_options = {str(chat[0]): (chat[1], chat[2]) for chat in chat_history}
 

--- a/pravah/llm.py
+++ b/pravah/llm.py
@@ -1,5 +1,6 @@
 from litellm import completion
 import os
+import re
 from dotenv import load_dotenv
 from tenacity import retry, stop_after_attempt, wait_fixed
 from pravah.prompts import generate_title_prompt
@@ -41,7 +42,7 @@ def chat_llm_v2_updated(messages, input, model='groq/llama3-70b-8192', system_pr
     messages.append({"content": response.choices[0].message.content, "role": "assistant"})
     return messages
 
-def generate_chat_title(prompt, response, model='groq/llama-3.1-8b-instant', temperature=0.5):
+def generate_chat_title(prompt, response, model='groq/llama-3.1-8b-instant', temperature=0.1):
     """
     Generates a chat title using an LLM.
     Falls back to a truncated prompt on failure.
@@ -57,5 +58,7 @@ def generate_chat_title(prompt, response, model='groq/llama-3.1-8b-instant', tem
 
     if isinstance(title, str):
         title = title.strip().replace('"', '').replace("'", "")
+        # Strip XML tags that the LLM may include (e.g. </title>)
+        title = re.sub(r'</?title>', '', title).strip()
         return title[:100] if title else prompt[:50]
     return prompt[:50]

--- a/pravah/llm.py
+++ b/pravah/llm.py
@@ -1,7 +1,5 @@
 from litellm import completion
-from rich.pretty import pprint
 import os
-# Load environment variables from .env file
 from dotenv import load_dotenv
 from tenacity import retry, stop_after_attempt, wait_fixed
 from pravah.prompts import generate_title_prompt
@@ -43,20 +41,21 @@ def chat_llm_v2_updated(messages, input, model='groq/llama3-70b-8192', system_pr
     messages.append({"content": response.choices[0].message.content, "role": "assistant"})
     return messages
 
-@retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
 def generate_chat_title(prompt, response, model='groq/llama-3.1-8b-instant', temperature=0.5):
     """
     Generates a chat title using an LLM.
+    Falls back to a truncated prompt on failure.
+    Note: completion_llm already has its own @retry(3 attempts), so we don't
+    add another retry here -- just catch the final failure.
     """
-    title_prompt = generate_title_prompt(prompt, response)
-    # Ensure completion_llm is called synchronously
+    title_prompt = generate_title_prompt(prompt, response[:500])
     try:
         title = completion_llm(title_prompt, model=model, temperature=temperature, stream=False)
     except Exception as e:
         print(f"Error generating title: {e}")
-        return prompt[:50] # Fallback to truncated prompt
+        return prompt[:50]
 
-    # Cleanup title (remove quotes, newlines)
     if isinstance(title, str):
-        return title.strip().replace('"', '').replace("'", "")
-    return title # Should be string
+        title = title.strip().replace('"', '').replace("'", "")
+        return title[:100] if title else prompt[:50]
+    return prompt[:50]

--- a/pravah/llm.py
+++ b/pravah/llm.py
@@ -4,6 +4,7 @@ import os
 # Load environment variables from .env file
 from dotenv import load_dotenv
 from tenacity import retry, stop_after_attempt, wait_fixed
+from pravah.prompts import generate_title_prompt
 
 # Safely get the API key
 # api_key = os.getenv('GROQ_API_KEY')
@@ -41,3 +42,21 @@ def chat_llm_v2_updated(messages, input, model='groq/llama3-70b-8192', system_pr
     print(response.choices[0].message.content)
     messages.append({"content": response.choices[0].message.content, "role": "assistant"})
     return messages
+
+@retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+def generate_chat_title(prompt, response, model='groq/llama-3.1-8b-instant', temperature=0.5):
+    """
+    Generates a chat title using an LLM.
+    """
+    title_prompt = generate_title_prompt(prompt, response)
+    # Ensure completion_llm is called synchronously
+    try:
+        title = completion_llm(title_prompt, model=model, temperature=temperature, stream=False)
+    except Exception as e:
+        print(f"Error generating title: {e}")
+        return prompt[:50] # Fallback to truncated prompt
+
+    # Cleanup title (remove quotes, newlines)
+    if isinstance(title, str):
+        return title.strip().replace('"', '').replace("'", "")
+    return title # Should be string

--- a/pravah/prompts.py
+++ b/pravah/prompts.py
@@ -376,3 +376,36 @@ def query_rewriter(prompt, previous_prompt=None, messages=None):
     return rendered_output
 if __name__ == "__main__":
     main()
+
+def generate_title_prompt(prompt, response):
+    """
+    Generates a prompt for creating a short, catchy title for a conversation.
+
+    Parameters:
+    - prompt: The user's input prompt.
+    - response: The assistant's response.
+
+    Returns:
+    - A string containing the prompt for title generation.
+    """
+    env = Environment(loader=FileSystemLoader(''))
+    template_string = """
+    <instructions>
+    You are an expert at summarizing conversations into short, catchy titles.
+    Given a user prompt and an assistant response, generate a title of 3-5 words that captures the essence of the interaction.
+    Do not use quotes.
+    Just return the title.
+    </instructions>
+
+    <user_prompt>
+    {{ prompt }}
+    </user_prompt>
+
+    <assistant_response>
+    {{ response }}
+    </assistant_response>
+
+    <title>
+    """
+    template = env.from_string(template_string)
+    return template.render(prompt=prompt, response=response)

--- a/pravah/prompts.py
+++ b/pravah/prompts.py
@@ -374,9 +374,6 @@ def query_rewriter(prompt, previous_prompt=None, messages=None):
     template = env.from_string(template_string)
     rendered_output = template.render(prompt=prompt, previous_prompt=previous_prompt, messages=messages)
     return rendered_output
-if __name__ == "__main__":
-    main()
-
 def generate_title_prompt(prompt, response):
     """
     Generates a prompt for creating a short, catchy title for a conversation.
@@ -388,7 +385,7 @@ def generate_title_prompt(prompt, response):
     Returns:
     - A string containing the prompt for title generation.
     """
-    env = Environment(loader=FileSystemLoader(''))
+    env = Environment()
     template_string = """
     <instructions>
     You are an expert at summarizing conversations into short, catchy titles.
@@ -409,3 +406,6 @@ def generate_title_prompt(prompt, response):
     """
     template = env.from_string(template_string)
     return template.render(prompt=prompt, response=response)
+
+if __name__ == "__main__":
+    main()

--- a/pravah/prompts.py
+++ b/pravah/prompts.py
@@ -374,6 +374,8 @@ def query_rewriter(prompt, previous_prompt=None, messages=None):
     template = env.from_string(template_string)
     rendered_output = template.render(prompt=prompt, previous_prompt=previous_prompt, messages=messages)
     return rendered_output
+
+
 def generate_title_prompt(prompt, response):
     """
     Generates a prompt for creating a short, catchy title for a conversation.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,55 @@
+
+import pytest
+from unittest.mock import MagicMock, patch
+import os
+import sys
+
+# Set dummy environment variables to avoid import errors
+os.environ['TVLY_API_KEY'] = 'test'
+os.environ['OPENAI_API_KEY'] = 'test'
+os.environ['COHERE_API_KEY'] = 'test'
+os.environ['BRAVE_API_KEY'] = 'test'
+os.environ['JINA_API_KEY'] = 'test'
+os.environ['LANGCHAIN_API_KEY'] = 'test'
+os.environ['LANGCHAIN_PROJECT'] = 'test'
+os.environ['GROQ_API_KEY'] = 'test'
+
+# We need to ensure app is imported with mocked streamlit and stays in sys.modules
+# or we use patch.object.
+# But since sys.modules['app'] is removed after the block, app.py might be re-executed if we import it again.
+# To avoid re-execution issues and sys.modules manipulation issues, let's just mock streamlit in sys.modules manually without context manager for the import,
+# or use a fixture that handles this.
+
+# Simpler approach: verify config logic without importing app if possible? No, Config is in app.
+# Let's use patch.dict but prevent it from clearing 'app'.
+# Actually, if we use patch.dict, we should do it in a fixture or just manually modify sys.modules.
+
+mock_streamlit = MagicMock()
+sys.modules['streamlit'] = mock_streamlit
+import app
+
+def test_config_has_title_model():
+    config = app.Config(search_tvly_api_key="test")
+    assert hasattr(config, 'title_model')
+    assert hasattr(config, 'title_model_temperature')
+    assert config.title_model == 'groq/llama-3.1-8b-instant'
+
+def test_check_api_keys_checks_title_model():
+    config = app.Config(search_tvly_api_key="test")
+    config.title_model = "openai/gpt-4"
+
+    # We want to verify check_api_keys detects missing key.
+    # But we set env vars above to import successfully.
+    # So inside the test, we need to unset OPENAI_API_KEY temporarily.
+
+    # We clear environ, so OPENAI_API_KEY is gone.
+    with patch.dict(os.environ, {}, clear=True):
+        # We mock streamlit inside app using patch.object
+        with patch.object(app, 'st') as mock_st:
+            mock_st.text_input.return_value = None
+
+            app.check_api_keys(config)
+
+            calls = [args[0] for args, _ in mock_st.info.call_args_list]
+            # Since config.title_model is openai/..., it should check OPENAI_API_KEY
+            assert any("OpenAI API key" in str(c) for c in calls)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,29 +4,36 @@ from unittest.mock import MagicMock, patch
 import os
 import sys
 
-# Set dummy environment variables to avoid import errors
-os.environ['TVLY_API_KEY'] = 'test'
-os.environ['OPENAI_API_KEY'] = 'test'
-os.environ['COHERE_API_KEY'] = 'test'
-os.environ['BRAVE_API_KEY'] = 'test'
-os.environ['JINA_API_KEY'] = 'test'
-os.environ['LANGCHAIN_API_KEY'] = 'test'
-os.environ['LANGCHAIN_PROJECT'] = 'test'
-os.environ['GROQ_API_KEY'] = 'test'
+# Set dummy environment variables before any imports
+os.environ.setdefault('TVLY_API_KEY', 'test')
+os.environ.setdefault('OPENAI_API_KEY', 'test')
+os.environ.setdefault('COHERE_API_KEY', 'test')
+os.environ.setdefault('BRAVE_API_KEY', 'test')
+os.environ.setdefault('JINA_API_KEY', 'test')
+os.environ.setdefault('LANGCHAIN_API_KEY', 'test')
+os.environ.setdefault('LANGCHAIN_PROJECT', 'test')
+os.environ.setdefault('GROQ_API_KEY', 'test')
 
-# We need to ensure app is imported with mocked streamlit and stays in sys.modules
-# or we use patch.object.
-# But since sys.modules['app'] is removed after the block, app.py might be re-executed if we import it again.
-# To avoid re-execution issues and sys.modules manipulation issues, let's just mock streamlit in sys.modules manually without context manager for the import,
-# or use a fixture that handles this.
+# Mock heavy dependencies that are not needed for config tests
+_mock_modules = [
+    'streamlit', 'rerankers', 'langsmith', 'langsmith.run_trees',
+    'pravah.retrieval', 'pravah.search',
+    'tavily', 'bs4', 'duckduckgo_search', 'brave_search',
+    'fastavro', 'faiss', 'lancedb', 'tantivy',
+    'pymupdf4llm', 'tiktoken', 'bm25s',
+]
 
-# Simpler approach: verify config logic without importing app if possible? No, Config is in app.
-# Let's use patch.dict but prevent it from clearing 'app'.
-# Actually, if we use patch.dict, we should do it in a fixture or just manually modify sys.modules.
+_saved = {}
+for mod in _mock_modules:
+    if mod not in sys.modules:
+        _saved[mod] = None
+        sys.modules[mod] = MagicMock()
+    else:
+        _saved[mod] = sys.modules[mod]
 
-mock_streamlit = MagicMock()
-sys.modules['streamlit'] = mock_streamlit
+# Now import app -- the heavy deps are mocked
 import app
+
 
 def test_config_has_title_model():
     config = app.Config(search_tvly_api_key="test")
@@ -34,22 +41,16 @@ def test_config_has_title_model():
     assert hasattr(config, 'title_model_temperature')
     assert config.title_model == 'groq/llama-3.1-8b-instant'
 
+
 def test_check_api_keys_checks_title_model():
     config = app.Config(search_tvly_api_key="test")
     config.title_model = "openai/gpt-4"
 
-    # We want to verify check_api_keys detects missing key.
-    # But we set env vars above to import successfully.
-    # So inside the test, we need to unset OPENAI_API_KEY temporarily.
-
-    # We clear environ, so OPENAI_API_KEY is gone.
     with patch.dict(os.environ, {}, clear=True):
-        # We mock streamlit inside app using patch.object
         with patch.object(app, 'st') as mock_st:
             mock_st.text_input.return_value = None
 
             app.check_api_keys(config)
 
-            calls = [args[0] for args, _ in mock_st.info.call_args_list]
-            # Since config.title_model is openai/..., it should check OPENAI_API_KEY
-            assert any("OpenAI API key" in str(c) for c in calls)
+            calls = [str(args[0]) for args, _ in mock_st.info.call_args_list]
+            assert any("OpenAI API key" in c for c in calls)

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -16,11 +16,11 @@ def create_tables_v2(conn):
     conn.execute("CREATE TABLE IF NOT EXISTS retrieved_chunks (conversation_uuid UUID, search_type TEXT, chunk TEXT, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
     conn.execute("CREATE TABLE IF NOT EXISTS re_written_prompt (conversation_uuid UUID, re_written_prompt TEXT, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
 
-    # Migration to add title
+    # Migration: add title column for existing databases
     try:
         conn.execute("ALTER TABLE chat_history ADD COLUMN title TEXT")
-    except:
-        pass
+    except Exception:
+        pass  # Column already exists
 
 def test_create_tables_adds_title(db_connection):
     # Simulate existing table without title

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -1,0 +1,58 @@
+
+import duckdb
+import pytest
+import uuid
+
+@pytest.fixture
+def db_connection():
+    conn = duckdb.connect(':memory:')
+    yield conn
+    conn.close()
+
+def create_tables_v2(conn):
+    conn.execute("CREATE TABLE IF NOT EXISTS chat_history (conversation_uuid UUID PRIMARY KEY, user_input TEXT, response TEXT)")
+    conn.execute("CREATE TABLE IF NOT EXISTS search_results (conversation_uuid UUID, search_result JSON, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
+    conn.execute("CREATE TABLE IF NOT EXISTS fetched_texts (url TEXT PRIMARY KEY, text TEXT)")
+    conn.execute("CREATE TABLE IF NOT EXISTS retrieved_chunks (conversation_uuid UUID, search_type TEXT, chunk TEXT, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
+    conn.execute("CREATE TABLE IF NOT EXISTS re_written_prompt (conversation_uuid UUID, re_written_prompt TEXT, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
+
+    # Migration to add title
+    try:
+        conn.execute("ALTER TABLE chat_history ADD COLUMN title TEXT")
+    except:
+        pass
+
+def test_create_tables_adds_title(db_connection):
+    # Simulate existing table without title
+    db_connection.execute("CREATE TABLE chat_history (conversation_uuid UUID PRIMARY KEY, user_input TEXT, response TEXT)")
+
+    # Run the function
+    create_tables_v2(db_connection)
+
+    # Verify column exists
+    result = db_connection.execute("DESCRIBE chat_history").fetchall()
+    columns = [row[0] for row in result]
+    assert "title" in columns
+
+def test_create_tables_idempotent(db_connection):
+    # Run twice
+    create_tables_v2(db_connection)
+    create_tables_v2(db_connection)
+
+    result = db_connection.execute("DESCRIBE chat_history").fetchall()
+    columns = [row[0] for row in result]
+    assert "title" in columns
+
+def save_to_duckdb_v2(conn, conversation_uuid, prompt, full_response, search_results, texts, urls, context_keyword, context_reranker, re_written_prompt, title):
+    conn.execute("INSERT INTO chat_history (conversation_uuid, user_input, response, title) VALUES (?, ?, ?, ?)", (conversation_uuid, prompt, full_response, title))
+    # Simplified other inserts for test
+    pass
+
+def test_save_to_duckdb_saves_title(db_connection):
+    create_tables_v2(db_connection)
+
+    uid = uuid.uuid4()
+    save_to_duckdb_v2(db_connection, uid, "hi", "hello", "{}", [], [], [], [], "hi", "Greeting")
+
+    result = db_connection.execute("SELECT title FROM chat_history WHERE conversation_uuid = ?", (uid,)).fetchone()
+    assert result[0] == "Greeting"

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -3,56 +3,75 @@ import duckdb
 import pytest
 import uuid
 
+
 @pytest.fixture
 def db_connection():
     conn = duckdb.connect(':memory:')
     yield conn
     conn.close()
 
-def create_tables_v2(conn):
-    conn.execute("CREATE TABLE IF NOT EXISTS chat_history (conversation_uuid UUID PRIMARY KEY, user_input TEXT, response TEXT)")
+
+def _create_tables(conn):
+    """Mirror of app.create_tables -- uses duckdb.CatalogException for migration."""
+    conn.execute("CREATE TABLE IF NOT EXISTS chat_history (conversation_uuid UUID PRIMARY KEY, user_input TEXT, response TEXT, title TEXT)")
+    # Migration: add title column for existing databases
+    try:
+        conn.execute("ALTER TABLE chat_history ADD COLUMN title TEXT")
+    except duckdb.CatalogException:
+        pass  # Column already exists
     conn.execute("CREATE TABLE IF NOT EXISTS search_results (conversation_uuid UUID, search_result JSON, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
     conn.execute("CREATE TABLE IF NOT EXISTS fetched_texts (url TEXT PRIMARY KEY, text TEXT)")
     conn.execute("CREATE TABLE IF NOT EXISTS retrieved_chunks (conversation_uuid UUID, search_type TEXT, chunk TEXT, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
     conn.execute("CREATE TABLE IF NOT EXISTS re_written_prompt (conversation_uuid UUID, re_written_prompt TEXT, FOREIGN KEY(conversation_uuid) REFERENCES chat_history(conversation_uuid))")
 
-    # Migration: add title column for existing databases
-    try:
-        conn.execute("ALTER TABLE chat_history ADD COLUMN title TEXT")
-    except Exception:
-        pass  # Column already exists
 
 def test_create_tables_adds_title(db_connection):
+    """Migration adds title column to a pre-existing table that lacks it."""
     # Simulate existing table without title
     db_connection.execute("CREATE TABLE chat_history (conversation_uuid UUID PRIMARY KEY, user_input TEXT, response TEXT)")
 
     # Run the function
-    create_tables_v2(db_connection)
+    _create_tables(db_connection)
 
     # Verify column exists
     result = db_connection.execute("DESCRIBE chat_history").fetchall()
     columns = [row[0] for row in result]
     assert "title" in columns
 
+
 def test_create_tables_idempotent(db_connection):
-    # Run twice
-    create_tables_v2(db_connection)
-    create_tables_v2(db_connection)
+    """Running create_tables twice does not raise."""
+    _create_tables(db_connection)
+    _create_tables(db_connection)
 
     result = db_connection.execute("DESCRIBE chat_history").fetchall()
     columns = [row[0] for row in result]
     assert "title" in columns
 
-def save_to_duckdb_v2(conn, conversation_uuid, prompt, full_response, search_results, texts, urls, context_keyword, context_reranker, re_written_prompt, title):
-    conn.execute("INSERT INTO chat_history (conversation_uuid, user_input, response, title) VALUES (?, ?, ?, ?)", (conversation_uuid, prompt, full_response, title))
-    # Simplified other inserts for test
-    pass
 
 def test_save_to_duckdb_saves_title(db_connection):
-    create_tables_v2(db_connection)
+    """Title is correctly persisted via INSERT."""
+    _create_tables(db_connection)
 
     uid = uuid.uuid4()
-    save_to_duckdb_v2(db_connection, uid, "hi", "hello", "{}", [], [], [], [], "hi", "Greeting")
+    db_connection.execute(
+        "INSERT INTO chat_history (conversation_uuid, user_input, response, title) VALUES (?, ?, ?, ?)",
+        (uid, "hi", "hello", "Greeting"),
+    )
 
     result = db_connection.execute("SELECT title FROM chat_history WHERE conversation_uuid = ?", (uid,)).fetchone()
     assert result[0] == "Greeting"
+
+
+def test_migration_catches_only_catalog_exception(db_connection):
+    """CatalogException is caught when column already exists, table still works."""
+    _create_tables(db_connection)
+
+    # Verify the table is fully functional after migration
+    uid = uuid.uuid4()
+    db_connection.execute(
+        "INSERT INTO chat_history (conversation_uuid, user_input, response, title) VALUES (?, ?, ?, ?)",
+        (uid, "test", "response", "Test Title"),
+    )
+    result = db_connection.execute("SELECT title FROM chat_history WHERE conversation_uuid = ?", (uid,)).fetchone()
+    assert result[0] == "Test Title"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,13 @@
+
+import pytest
+from pravah.prompts import generate_title_prompt
+
+def test_generate_title_prompt():
+    prompt = "What is the capital of France?"
+    response = "The capital of France is Paris."
+
+    title_prompt = generate_title_prompt(prompt, response)
+
+    assert prompt in title_prompt
+    assert response in title_prompt
+    assert "title" in title_prompt.lower()

--- a/tests/test_title_generation.py
+++ b/tests/test_title_generation.py
@@ -2,24 +2,80 @@
 from unittest.mock import MagicMock, patch
 import pytest
 
-# This import will fail until I implement the function
-try:
-    from pravah.llm import generate_chat_title
-except ImportError:
-    generate_chat_title = None
+from pravah.llm import generate_chat_title
+
 
 def test_generate_chat_title():
-    if generate_chat_title is None:
-        pytest.fail("generate_chat_title not implemented yet")
-
-    prompt = "Hi"
-    response = "Hello"
-
-    # Mock completion_llm inside pravah.llm
+    """Basic title generation returns the LLM output."""
     with patch('pravah.llm.completion_llm') as mock_llm:
         mock_llm.return_value = "My Title"
 
-        title = generate_chat_title(prompt, response)
+        title = generate_chat_title("Hi", "Hello")
 
         assert title == "My Title"
-        # validation of arguments passed to completion_llm could be added here
+        mock_llm.assert_called_once()
+
+
+def test_generate_chat_title_strips_quotes():
+    """Quotes and whitespace are cleaned from the LLM output."""
+    with patch('pravah.llm.completion_llm') as mock_llm:
+        mock_llm.return_value = '  "A Great Title"  '
+
+        title = generate_chat_title("Hi", "Hello")
+
+        assert title == "A Great Title"
+
+
+def test_generate_chat_title_fallback_on_error():
+    """Falls back to truncated prompt when LLM raises an exception."""
+    with patch('pravah.llm.completion_llm') as mock_llm:
+        mock_llm.side_effect = Exception("API error")
+
+        title = generate_chat_title("What is the capital of France?", "Paris")
+
+        assert title == "What is the capital of France?"[:50]
+
+
+def test_generate_chat_title_fallback_on_empty_string():
+    """Falls back to truncated prompt when LLM returns empty string."""
+    with patch('pravah.llm.completion_llm') as mock_llm:
+        mock_llm.return_value = "   "
+
+        title = generate_chat_title("My long prompt here", "Response")
+
+        assert title == "My long prompt here"[:50]
+
+
+def test_generate_chat_title_truncates_long_title():
+    """Titles longer than 100 characters are truncated."""
+    with patch('pravah.llm.completion_llm') as mock_llm:
+        mock_llm.return_value = "A" * 150
+
+        title = generate_chat_title("Hi", "Hello")
+
+        assert len(title) == 100
+
+
+def test_generate_chat_title_truncates_response_input():
+    """Only the first 500 chars of response are passed to the title prompt."""
+    long_response = "x" * 1000
+    with patch('pravah.llm.completion_llm') as mock_llm:
+        mock_llm.return_value = "Short Title"
+        with patch('pravah.llm.generate_title_prompt') as mock_prompt:
+            mock_prompt.return_value = "fake prompt"
+
+            generate_chat_title("Hi", long_response)
+
+            # Verify response was truncated to 500 chars
+            call_args = mock_prompt.call_args
+            assert len(call_args[0][1]) == 500
+
+
+def test_generate_chat_title_non_string_fallback():
+    """Falls back to truncated prompt when LLM returns non-string."""
+    with patch('pravah.llm.completion_llm') as mock_llm:
+        mock_llm.return_value = 42  # non-string
+
+        title = generate_chat_title("My prompt", "Response")
+
+        assert title == "My prompt"[:50]

--- a/tests/test_title_generation.py
+++ b/tests/test_title_generation.py
@@ -79,3 +79,23 @@ def test_generate_chat_title_non_string_fallback():
         title = generate_chat_title("My prompt", "Response")
 
         assert title == "My prompt"[:50]
+
+
+def test_generate_chat_title_strips_xml_title_tags():
+    """XML <title> and </title> tags are stripped from LLM output."""
+    with patch('pravah.llm.completion_llm') as mock_llm:
+        mock_llm.return_value = "Great Chat Title</title>"
+
+        title = generate_chat_title("Hi", "Hello")
+
+        assert title == "Great Chat Title"
+
+
+def test_generate_chat_title_strips_opening_title_tag():
+    """Opening <title> tag is also stripped from LLM output."""
+    with patch('pravah.llm.completion_llm') as mock_llm:
+        mock_llm.return_value = "<title>Great Chat Title</title>"
+
+        title = generate_chat_title("Hi", "Hello")
+
+        assert title == "Great Chat Title"

--- a/tests/test_title_generation.py
+++ b/tests/test_title_generation.py
@@ -1,0 +1,25 @@
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+# This import will fail until I implement the function
+try:
+    from pravah.llm import generate_chat_title
+except ImportError:
+    generate_chat_title = None
+
+def test_generate_chat_title():
+    if generate_chat_title is None:
+        pytest.fail("generate_chat_title not implemented yet")
+
+    prompt = "Hi"
+    response = "Hello"
+
+    # Mock completion_llm inside pravah.llm
+    with patch('pravah.llm.completion_llm') as mock_llm:
+        mock_llm.return_value = "My Title"
+
+        title = generate_chat_title(prompt, response)
+
+        assert title == "My Title"
+        # validation of arguments passed to completion_llm could be added here


### PR DESCRIPTION
This PR implements smart chat titles. It uses an LLM to generate a short, catchy title for each conversation turn and stores it in the DuckDB database. The sidebar history list now displays these titles instead of the raw user prompt.

Key changes:
- `pravah/prompts.py`: Added `generate_title_prompt` Jinja2 template.
- `pravah/llm.py`: Added `generate_chat_title` function.
- `app.py`:
    - Database schema update to include `title`.
    - Logic to generate and save title.
    - Sidebar UI update to show titles.
- `tests/`: Added unit tests for prompt generation and title generation logic.

---
*PR created automatically by Jules for task [1399567442225381321](https://jules.google.com/task/1399567442225381321) started by @jayshah5696*