### PR TITLE
🔒 [security fix] Fix potential SQL Injection in LanceDB Queries

### DIFF
--- a/pravah/retrieval.py
+++ b/pravah/retrieval.py
@@ -41,7 +41,7 @@ class LiteLLMEmbeddingClient:
 @traceable
 class RetrievalEngine:
     def __init__(self, texts: List[dict],
-                uuid_input: str,
+                uuid_input: str = None,
                 chunk_size: int = 500,
                 overlap: int = 100,
                 chunking_method: str = 'tokens',
@@ -55,6 +55,15 @@ class RetrievalEngine:
         self.tokens = tokens
         self.use_lancedb = use_lancedb
         self.chunking_method = chunking_method
+        if uuid_input is not None:
+            try:
+                uuid.UUID(uuid_input)
+            except (ValueError, TypeError):
+                raise ValueError(f"Invalid UUID format: {uuid_input}")
+        elif use_lancedb:
+            uuid_input = str(uuid.uuid4())
+
+        self.uuid_input = uuid_input
         self.chunks = self.chunk_texts(texts, uuid_input=uuid_input)
         self.embed_client = embed_client
         self.embeddings = None
@@ -81,7 +90,6 @@ class RetrievalEngine:
                 chunked_texts = self.chunk_text(text, self.chunk_size, self.overlap)
             for chunk in chunked_texts:
                 chunks.append({'content': chunk, 'url': url, 'uuid': uuid_input})
-        self.uuid_input = uuid_input
         return chunks
 
     def chunk_text(self, text, max_char_length=1000, overlap=0):
@@ -324,21 +332,22 @@ class RetrievalEngine:
         self.tbl.create_fts_index("content",replace=True)
 
     async def lancedb_keyword_search(self, query: str, top_k: int = 5) -> List[dict]:
-        results = self.tbl.search(query, query_type='fts').where(f"uuid={self.uuid_input}").limit(top_k).to_list()
+        results = self.tbl.search(query, query_type='fts').where(f"uuid='{self.uuid_input}'").limit(top_k).to_list()
         return results
 
     async def lancedb_semantic_search(self, query: str, top_k: int = 5) -> List[dict]:
-        results = self.tbl.search(query, query_type='vector').where(f"uuid={self.uuid_input}").limit(top_k).to_list()
+        results = self.tbl.search(query, query_type='vector').where(f"uuid='{self.uuid_input}'").limit(top_k).to_list()
         return results
 
     async def lancedb_hybrid_search(self, query: str, top_k: int = 5) -> List[dict]:
-        results = self.tbl.search(query, query_type='hybrid').where(f"uuid={self.uuid_input}").limit(top_k).to_list()
+        results = self.tbl.search(query, query_type='hybrid').where(f"uuid='{self.uuid_input}'").limit(top_k).to_list()
         return results
 
     async def lancedb_combined_search(self, query: str, top_k: int = 5) -> List[dict]:
         from lancedb.rerankers import CohereReranker
         reranker = CohereReranker(column='content')
         results = (self.tbl.search(query, query_type='hybrid')
+                   .where(f"uuid='{self.uuid_input}'")
                    .limit(top_k*2)
                    .rerank(reranker=reranker).limit(top_k))
         return results.to_list()

--- a/pravah/retrieval.py
+++ b/pravah/retrieval.py
@@ -56,6 +56,8 @@ class RetrievalEngine:
         self.use_lancedb = use_lancedb
         self.chunking_method = chunking_method
         if uuid_input is not None:
+            if not isinstance(uuid_input, str):
+                raise ValueError(f"Invalid UUID format: {uuid_input}")
             try:
                 uuid.UUID(uuid_input)
             except (ValueError, TypeError):
@@ -331,23 +333,32 @@ class RetrievalEngine:
         self.tbl.add(self.chunks)
         self.tbl.create_fts_index("content",replace=True)
 
+    def _uuid_filter(self) -> str:
+        """Build a LanceDB .where() filter for session isolation.
+
+        Safe to interpolate because self.uuid_input is validated as a UUID
+        in __init__ (only hex digits and dashes), so it cannot contain
+        SQL metacharacters like quotes or semicolons.
+        """
+        return f"uuid='{self.uuid_input}'"
+
     async def lancedb_keyword_search(self, query: str, top_k: int = 5) -> List[dict]:
-        results = self.tbl.search(query, query_type='fts').where(f"uuid='{self.uuid_input}'").limit(top_k).to_list()
+        results = self.tbl.search(query, query_type='fts').where(self._uuid_filter()).limit(top_k).to_list()
         return results
 
     async def lancedb_semantic_search(self, query: str, top_k: int = 5) -> List[dict]:
-        results = self.tbl.search(query, query_type='vector').where(f"uuid='{self.uuid_input}'").limit(top_k).to_list()
+        results = self.tbl.search(query, query_type='vector').where(self._uuid_filter()).limit(top_k).to_list()
         return results
 
     async def lancedb_hybrid_search(self, query: str, top_k: int = 5) -> List[dict]:
-        results = self.tbl.search(query, query_type='hybrid').where(f"uuid='{self.uuid_input}'").limit(top_k).to_list()
+        results = self.tbl.search(query, query_type='hybrid').where(self._uuid_filter()).limit(top_k).to_list()
         return results
 
     async def lancedb_combined_search(self, query: str, top_k: int = 5) -> List[dict]:
         from lancedb.rerankers import CohereReranker
         reranker = CohereReranker(column='content')
         results = (self.tbl.search(query, query_type='hybrid')
-                   .where(f"uuid='{self.uuid_input}'")
+                   .where(self._uuid_filter())
                    .limit(top_k*2)
                    .rerank(reranker=reranker).limit(top_k))
         return results.to_list()

--- a/tests/test_security_fix.py
+++ b/tests/test_security_fix.py
@@ -1,5 +1,5 @@
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, AsyncMock
 
 # Mock dependencies that are not installed before importing RetrievalEngine
 sys.modules['numpy'] = MagicMock()
@@ -46,11 +46,36 @@ def test_retrieval_engine_invalid_uuid(mock_dependencies):
     with pytest.raises(ValueError, match="Invalid UUID format"):
         RetrievalEngine(texts, uuid_input=invalid_uuid, use_lancedb=True)
 
+def test_retrieval_engine_rejects_sql_injection_payload(mock_dependencies):
+    """Verify that SQL injection payloads are rejected by UUID validation."""
+    texts = [{'content': 'hello', 'url': 'http://example.com'}]
+
+    injection_payloads = [
+        "' OR 1=1 --",
+        "'; DROP TABLE pravah_chunks; --",
+        "' UNION SELECT * FROM pravah_chunks WHERE '1'='1",
+        "abc' OR ''='",
+        "1; DELETE FROM pravah_chunks",
+    ]
+
+    for payload in injection_payloads:
+        with pytest.raises(ValueError, match="Invalid UUID format"):
+            RetrievalEngine(texts, uuid_input=payload, use_lancedb=True)
+
+def test_retrieval_engine_rejects_non_string_uuid(mock_dependencies):
+    """Verify that non-string types are rejected by UUID validation."""
+    texts = [{'content': 'hello', 'url': 'http://example.com'}]
+
+    with pytest.raises(ValueError, match="Invalid UUID format"):
+        RetrievalEngine(texts, uuid_input=12345, use_lancedb=True)
+
+    with pytest.raises(ValueError, match="Invalid UUID format"):
+        RetrievalEngine(texts, uuid_input=['not', 'a', 'uuid'], use_lancedb=True)
+
 def test_retrieval_engine_valid_uuid(mock_dependencies):
     texts = [{'content': 'hello', 'url': 'http://example.com'}]
     valid_uuid = str(uuid.uuid4())
 
-    # We need to mock the chunk_texts call too or its return value
     with patch('pravah.retrieval.RetrievalEngine.chunk_texts') as mock_chunks:
         mock_chunks.return_value = []
         engine = RetrievalEngine(texts, uuid_input=valid_uuid, use_lancedb=False)
@@ -72,40 +97,56 @@ def test_retrieval_engine_none_uuid(mock_dependencies):
             # Verify it's a valid UUID
             uuid.UUID(engine.uuid_input)
 
-def test_lancedb_search_quoting(mock_dependencies):
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_uuid_filter_format(mock_dependencies):
+    """Verify _uuid_filter produces correctly quoted filter strings."""
     texts = [{'content': 'hello', 'url': 'http://example.com'}]
     valid_uuid = str(uuid.uuid4())
+
+    with patch('pravah.retrieval.RetrievalEngine.chunk_texts') as mock_chunks:
+        mock_chunks.return_value = []
+        engine = RetrievalEngine(texts, uuid_input=valid_uuid, use_lancedb=False)
+        expected = f"uuid='{valid_uuid}'"
+        assert engine._uuid_filter() == expected
+
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_lancedb_search_quoting(mock_dependencies):
+    """Verify all LanceDB search methods apply the UUID filter."""
+    texts = [{'content': 'hello', 'url': 'http://example.com'}]
+    valid_uuid = str(uuid.uuid4())
+    expected_filter = f"uuid='{valid_uuid}'"
 
     async def run_test():
         with patch('pravah.retrieval.RetrievalEngine.chunk_texts') as mock_chunks:
             mock_chunks.return_value = []
-            # We need to bypass asyncio.run(self.create_lancedb_table()) in __init__
             with patch('pravah.retrieval.asyncio.run'):
                 engine = RetrievalEngine(texts, uuid_input=valid_uuid, use_lancedb=True)
-                engine.tbl = MagicMock()
+
+                # Build a proper mock chain that tracks calls correctly
+                mock_tbl = MagicMock()
+                engine.tbl = mock_tbl
 
                 # Test lancedb_keyword_search
                 await engine.lancedb_keyword_search("query")
-                engine.tbl.search.assert_called_with("query", query_type='fts')
-                engine.tbl.search().where.assert_called_with(f"uuid='{valid_uuid}'")
+                mock_tbl.search.assert_called_with("query", query_type='fts')
+                mock_tbl.search.return_value.where.assert_called_with(expected_filter)
 
                 # Test lancedb_semantic_search
-                engine.tbl.reset_mock()
+                mock_tbl.reset_mock()
                 await engine.lancedb_semantic_search("query")
-                engine.tbl.search.assert_called_with("query", query_type='vector')
-                engine.tbl.search().where.assert_called_with(f"uuid='{valid_uuid}'")
+                mock_tbl.search.assert_called_with("query", query_type='vector')
+                mock_tbl.search.return_value.where.assert_called_with(expected_filter)
 
                 # Test lancedb_hybrid_search
-                engine.tbl.reset_mock()
+                mock_tbl.reset_mock()
                 await engine.lancedb_hybrid_search("query")
-                engine.tbl.search.assert_called_with("query", query_type='hybrid')
-                engine.tbl.search().where.assert_called_with(f"uuid='{valid_uuid}'")
+                mock_tbl.search.assert_called_with("query", query_type='hybrid')
+                mock_tbl.search.return_value.where.assert_called_with(expected_filter)
 
                 # Test lancedb_combined_search
-                engine.tbl.reset_mock()
+                mock_tbl.reset_mock()
                 await engine.lancedb_combined_search("query")
-                engine.tbl.search.assert_called_with("query", query_type='hybrid')
-                # Check that where was called with the quoted uuid
-                engine.tbl.search().where.assert_called_with(f"uuid='{valid_uuid}'")
+                mock_tbl.search.assert_called_with("query", query_type='hybrid')
+                mock_tbl.search.return_value.where.assert_called_with(expected_filter)
 
     asyncio.run(run_test())

--- a/tests/test_security_fix.py
+++ b/tests/test_security_fix.py
@@ -1,0 +1,111 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+# Mock dependencies that are not installed before importing RetrievalEngine
+sys.modules['numpy'] = MagicMock()
+sys.modules['bm25s'] = MagicMock()
+sys.modules['faiss'] = MagicMock()
+sys.modules['fastavro'] = MagicMock()
+sys.modules['dotenv'] = MagicMock()
+sys.modules['tiktoken'] = MagicMock()
+sys.modules['litellm'] = MagicMock()
+sys.modules['rerankers'] = MagicMock()
+sys.modules['cachetools'] = MagicMock()
+sys.modules['cachetools.keys'] = MagicMock()
+sys.modules['lancedb'] = MagicMock()
+sys.modules['lancedb.pydantic'] = MagicMock()
+sys.modules['lancedb.embeddings'] = MagicMock()
+sys.modules['lancedb.rerankers'] = MagicMock()
+
+# Special mock for langsmith to keep the traceable decorator working
+mock_langsmith = MagicMock()
+def mock_traceable(obj):
+    return obj
+mock_langsmith.traceable = mock_traceable
+sys.modules['langsmith'] = mock_langsmith
+
+import pytest
+import uuid
+import asyncio
+from pravah.retrieval import RetrievalEngine
+
+@pytest.fixture
+def mock_dependencies():
+    with patch('pravah.retrieval.lancedb.connect'), \
+         patch('pravah.retrieval.RetrievalEngine.create_lancedb_table'), \
+         patch('pravah.retrieval.RetrievalEngine.add_chunks_to_lancedb'), \
+         patch('pravah.retrieval.RetrievalEngine.create_bm25'), \
+         patch('pravah.retrieval.LiteLLMEmbeddingClient'), \
+         patch('pravah.retrieval.Reranker'):
+        yield
+
+def test_retrieval_engine_invalid_uuid(mock_dependencies):
+    texts = [{'content': 'hello', 'url': 'http://example.com'}]
+    invalid_uuid = "not-a-uuid"
+
+    with pytest.raises(ValueError, match="Invalid UUID format"):
+        RetrievalEngine(texts, uuid_input=invalid_uuid, use_lancedb=True)
+
+def test_retrieval_engine_valid_uuid(mock_dependencies):
+    texts = [{'content': 'hello', 'url': 'http://example.com'}]
+    valid_uuid = str(uuid.uuid4())
+
+    # We need to mock the chunk_texts call too or its return value
+    with patch('pravah.retrieval.RetrievalEngine.chunk_texts') as mock_chunks:
+        mock_chunks.return_value = []
+        engine = RetrievalEngine(texts, uuid_input=valid_uuid, use_lancedb=False)
+        assert engine.uuid_input == valid_uuid
+
+def test_retrieval_engine_none_uuid(mock_dependencies):
+    texts = [{'content': 'hello', 'url': 'http://example.com'}]
+
+    with patch('pravah.retrieval.RetrievalEngine.chunk_texts') as mock_chunks:
+        mock_chunks.return_value = []
+        # Case 1: use_lancedb=False, uuid_input=None should stay None
+        engine = RetrievalEngine(texts, uuid_input=None, use_lancedb=False)
+        assert engine.uuid_input is None
+
+        # Case 2: use_lancedb=True, uuid_input=None should generate a new UUID
+        with patch('pravah.retrieval.asyncio.run'):
+            engine = RetrievalEngine(texts, uuid_input=None, use_lancedb=True)
+            assert engine.uuid_input is not None
+            # Verify it's a valid UUID
+            uuid.UUID(engine.uuid_input)
+
+def test_lancedb_search_quoting(mock_dependencies):
+    texts = [{'content': 'hello', 'url': 'http://example.com'}]
+    valid_uuid = str(uuid.uuid4())
+
+    async def run_test():
+        with patch('pravah.retrieval.RetrievalEngine.chunk_texts') as mock_chunks:
+            mock_chunks.return_value = []
+            # We need to bypass asyncio.run(self.create_lancedb_table()) in __init__
+            with patch('pravah.retrieval.asyncio.run'):
+                engine = RetrievalEngine(texts, uuid_input=valid_uuid, use_lancedb=True)
+                engine.tbl = MagicMock()
+
+                # Test lancedb_keyword_search
+                await engine.lancedb_keyword_search("query")
+                engine.tbl.search.assert_called_with("query", query_type='fts')
+                engine.tbl.search().where.assert_called_with(f"uuid='{valid_uuid}'")
+
+                # Test lancedb_semantic_search
+                engine.tbl.reset_mock()
+                await engine.lancedb_semantic_search("query")
+                engine.tbl.search.assert_called_with("query", query_type='vector')
+                engine.tbl.search().where.assert_called_with(f"uuid='{valid_uuid}'")
+
+                # Test lancedb_hybrid_search
+                engine.tbl.reset_mock()
+                await engine.lancedb_hybrid_search("query")
+                engine.tbl.search.assert_called_with("query", query_type='hybrid')
+                engine.tbl.search().where.assert_called_with(f"uuid='{valid_uuid}'")
+
+                # Test lancedb_combined_search
+                engine.tbl.reset_mock()
+                await engine.lancedb_combined_search("query")
+                engine.tbl.search.assert_called_with("query", query_type='hybrid')
+                # Check that where was called with the quoted uuid
+                engine.tbl.search().where.assert_called_with(f"uuid='{valid_uuid}'")
+
+    asyncio.run(run_test())


### PR DESCRIPTION
This PR addresses a security vulnerability where `uuid_input` was directly interpolated into LanceDB SQL-like filters without validation or quoting. 

🎯 **What:** The vulnerability fixed is a potential SQL Injection in LanceDB queries within `pravah/retrieval.py`.
⚠️ **Risk:** If left unfixed, a malicious user could potentially bypass session isolation and access data from other conversations, or cause application errors via SQL syntax injection.
🛡️ **Solution:** I implemented strict validation of the `uuid_input` using the `uuid` module and ensured that all LanceDB `.where()` clauses use properly quoted string literals. I also added the missing isolation filter to the `lancedb_combined_search` method. Additionally, `uuid_input` was made optional to avoid breaking existing integrations, with safe UUID generation as a fallback when using LanceDB.

---
*PR created automatically by Jules for task [10623412779353185453](https://jules.google.com/task/10623412779353185453) started by @jayshah5696*