### PR TITLE
🔒 [security fix] Replace unsafe eval() with secure AST-based evaluator in calculate tool

### DIFF
--- a/pravah/tools.py
+++ b/pravah/tools.py
@@ -453,7 +453,9 @@ def calculate(expression: str) -> str:
     Returns:
         The calculated result
     """
+    import ast
     import math
+    import operator
 
     # Safe evaluation with only math functions
     allowed_names = {
@@ -474,12 +476,44 @@ def calculate(expression: str) -> str:
         "e": math.e,
     }
 
-    try:
-        # Remove any potentially dangerous characters
-        safe_expr = expression.replace("^", "**")
+    operators = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+        ast.Pow: operator.pow,
+        ast.BitXor: operator.pow,  # Support ^ as power
+        ast.USub: operator.neg,
+        ast.UAdd: operator.pos,
+    }
 
-        # Evaluate with restricted namespace
-        result = eval(safe_expr, {"__builtins__": {}}, allowed_names)
+    def _eval_node(node):
+        if isinstance(node, ast.Constant):
+            return node.value
+        elif isinstance(node, ast.BinOp):
+            if type(node.op) in operators:
+                return operators[type(node.op)](_eval_node(node.left), _eval_node(node.right))
+            raise ValueError(f"Operator {type(node.op).__name__} not supported")
+        elif isinstance(node, ast.UnaryOp):
+            if type(node.op) in operators:
+                return operators[type(node.op)](_eval_node(node.operand))
+            raise ValueError(f"Operator {type(node.op).__name__} not supported")
+        elif isinstance(node, ast.Call):
+            func = _eval_node(node.func)
+            if not callable(func):
+                raise ValueError(f"Not a function: {func}")
+            return func(*(_eval_node(arg) for arg in node.args))
+        elif isinstance(node, ast.Name):
+            if node.id in allowed_names:
+                return allowed_names[node.id]
+            raise ValueError(f"Unknown name: {node.id}")
+        else:
+            raise ValueError(f"Unsupported operation: {type(node).__name__}")
+
+    try:
+        # Parse the expression into an AST
+        tree = ast.parse(expression, mode="eval")
+        result = _eval_node(tree.body)
         return f"{expression} = {result}"
     except Exception as e:
         return f"Could not calculate '{expression}': {str(e)}"

--- a/tests/test_calculate_security.py
+++ b/tests/test_calculate_security.py
@@ -1,0 +1,63 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mocking missing dependencies before importing pravah.tools to allow unit tests in restricted environment
+sys.modules["langchain_core"] = MagicMock()
+def mock_tool(fn):
+    return fn
+sys.modules["langchain_core.tools"] = MagicMock()
+sys.modules["langchain_core.tools"].tool = mock_tool
+sys.modules["langchain_core.runnables"] = MagicMock()
+sys.modules["pravah.search"] = MagicMock()
+sys.modules["pravah.llm"] = MagicMock()
+sys.modules["pravah.memory"] = MagicMock()
+
+from pravah.tools import calculate
+
+def test_calculate_valid_expressions():
+    """Verify that standard math expressions work as expected."""
+    assert "2 + 2 = 4" in calculate("2 + 2")
+    assert "sqrt(16) = 4.0" in calculate("sqrt(16)")
+    assert "2**3 = 8" in calculate("2**3")
+    assert "2^3 = 8" in calculate("2^3")
+    assert "sin(pi/2) = 1.0" in calculate("sin(pi/2)")
+
+def test_calculate_security_blocked():
+    """Verify that attempts to escape the sandbox are blocked."""
+    # Attribute access should be blocked
+    payload = "(1).__class__.__mro__[1].__subclasses__()"
+    result = calculate(payload)
+    assert "Could not calculate" in result
+    assert "Unsupported operation: Attribute" in result
+
+    # List comprehension should be blocked
+    payload = "[x for x in (1, 2, 3)]"
+    result = calculate(payload)
+    assert "Could not calculate" in result
+    assert "Unsupported operation: ListComp" in result
+
+    # Builtin access should be blocked
+    payload = "__builtins__"
+    result = calculate(payload)
+    assert "Could not calculate" in result
+    assert "Unknown name: __builtins__" in result
+
+if __name__ == "__main__":
+    # Manual test runner
+    print("Running security tests for 'calculate' tool...")
+
+    try:
+        test_calculate_valid_expressions()
+        print("test_calculate_valid_expressions: PASSED")
+    except AssertionError as e:
+        print(f"test_calculate_valid_expressions: FAILED: {e}")
+        sys.exit(1)
+
+    try:
+        test_calculate_security_blocked()
+        print("test_calculate_security_blocked: PASSED (Exploits blocked)")
+    except AssertionError as e:
+        print(f"test_calculate_security_blocked: FAILED: {e}")
+        sys.exit(1)
+
+    print("All security tests passed.")


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the use of `eval()` on user-provided input in the `calculate` tool.
⚠️ **Risk:** This could be exploited by an attacker to execute arbitrary Python code on the server, potentially leading to a full system compromise.
🛡️ **Solution:** The fix replaces `eval()` with a custom evaluator that uses the `ast` module to parse the expression into an Abstract Syntax Tree. It then recursively traverses the tree, only allowing specific, safe nodes (constants, binary/unary operators, and a whitelist of math functions). This ensures that dangerous operations like attribute access (`.__class__`), imports, or arbitrary function calls are naturally blocked.

---
*PR created automatically by Jules for task [10918757374960026612](https://jules.google.com/task/10918757374960026612) started by @jayshah5696*