### PR TITLE
🔒 [security fix] Fix RCE vulnerability in calculate tool

### DIFF
--- a/pravah/tools.py
+++ b/pravah/tools.py
@@ -454,6 +454,8 @@ def calculate(expression: str) -> str:
         The calculated result
     """
     import math
+    import ast
+    import operator
 
     # Safe evaluation with only math functions
     allowed_names = {
@@ -474,12 +476,49 @@ def calculate(expression: str) -> str:
         "e": math.e,
     }
 
-    try:
-        # Remove any potentially dangerous characters
-        safe_expr = expression.replace("^", "**")
+    # Map AST operators to operator functions
+    operators = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+        ast.Pow: operator.pow,
+        ast.BitXor: operator.pow,  # Support ^ as power
+        ast.USub: operator.neg,
+        ast.UAdd: operator.pos,
+    }
 
-        # Evaluate with restricted namespace
-        result = eval(safe_expr, {"__builtins__": {}}, allowed_names)
+    def _eval_node(node):
+        if isinstance(node, ast.Expression):
+            return _eval_node(node.body)
+        elif isinstance(node, ast.Num):  # For Python < 3.8
+            return node.n
+        elif isinstance(node, ast.Constant):  # For Python >= 3.8
+            return node.value
+        elif isinstance(node, ast.BinOp):
+            left = _eval_node(node.left)
+            right = _eval_node(node.right)
+            return operators[type(node.op)](left, right)
+        elif isinstance(node, ast.UnaryOp):
+            operand = _eval_node(node.operand)
+            return operators[type(node.op)](operand)
+        elif isinstance(node, ast.Call):
+            func = _eval_node(node.func)
+            args = [_eval_node(arg) for arg in node.args]
+            return func(*args)
+        elif isinstance(node, ast.Name):
+            if node.id in allowed_names:
+                return allowed_names[node.id]
+            raise ValueError(f"Name '{node.id}' is not allowed")
+        else:
+            raise TypeError(f"Unsupported AST node type: {type(node).__name__}")
+
+    try:
+        # Parse the expression into an AST
+        tree = ast.parse(expression, mode="eval")
+
+        # Evaluate the AST
+        result = _eval_node(tree)
         return f"{expression} = {result}"
     except Exception as e:
         return f"Could not calculate '{expression}': {str(e)}"

--- a/tests/test_security_calculate.py
+++ b/tests/test_security_calculate.py
@@ -1,0 +1,78 @@
+import pytest
+import math
+import sys
+from unittest.mock import MagicMock
+
+# Mocking external dependencies
+mock_modules = [
+    "langchain_core",
+    "langchain_core.tools",
+    "langchain_core.runnables",
+    "pravah.search",
+    "pravah.llm",
+    "pravah.memory",
+    "litellm",
+    "langgraph",
+    "langgraph.checkpoint",
+    "aiosqlite",
+    "tavily",
+    "beautifulsoup4",
+    "duckduckgo_search",
+    "bm25s",
+    "rerankers",
+    "faiss",
+    "lancedb",
+    "tantivy",
+    "openai",
+    "anthropic",
+    "cohere",
+    "google.genai",
+    "pymupdf4llm",
+    "tiktoken",
+    "streamlit",
+    "aiohttp",
+    "duckdb",
+]
+
+for mod in mock_modules:
+    sys.modules[mod] = MagicMock()
+
+# Explicitly make @tool an identity decorator
+def identity_decorator(f):
+    return f
+
+sys.modules['langchain_core.tools'].tool = identity_decorator
+
+# Now we can import calculate
+from pravah.tools import calculate
+
+def test_calculate_basic():
+    """Test basic math operations."""
+    assert "2 + 2 = 4" in calculate("2 + 2")
+    assert "10 / 2 = 5.0" in calculate("10 / 2")
+    assert "2 ** 3 = 8" in calculate("2 ** 3")
+    assert "2 ^ 3 = 8" in calculate("2 ^ 3") # Test ^ replacement
+
+def test_calculate_math_functions():
+    """Test allowed math functions."""
+    assert "sqrt(16) = 4.0" in calculate("sqrt(16)")
+    assert "sin(0) = 0.0" in calculate("sin(0)")
+    assert f"pi = {math.pi}" in calculate("pi")
+
+def test_calculate_invalid_expression():
+    """Test handling of invalid expressions."""
+    result = calculate("not a math expression")
+    assert "Could not calculate" in result
+
+def test_calculate_vulnerability_rce():
+    """
+    Test for the RCE vulnerability.
+    """
+    # This exploit attempts to call 'echo VULNERABLE'
+    exploit = "[c for c in ().__class__.__mro__[-1].__subclasses__() if c.__name__ == '_wrap_close'][0].__init__.__globals__['system']('echo VULNERABLE')"
+
+    result = calculate(exploit)
+
+    # After fix, this should return an error message
+    assert "Could not calculate" in result
+    assert "Unsupported AST node type" in result or "Name" in result


### PR DESCRIPTION
The `calculate` tool in `pravah/tools.py` was vulnerable to Remote Code Execution (RCE) because it used the `eval()` function on user-provided input. Although it used a restricted namespace, attackers could still escape the sandbox using Python object inheritance (e.g., `().__class__.__mro__[-1].__subclasses__()`).

I have replaced `eval()` with a custom evaluator that parses the expression into an Abstract Syntax Tree (AST) and recursively evaluates it. This evaluator only permits a strict whitelist of safe operations and names, effectively neutralizing any RCE attempts while maintaining support for basic arithmetic and allowed math functions.

**Changes:**
- Modified `pravah/tools.py`: Replaced `eval()` with a secure AST-based walker.
- Added `tests/test_security_calculate.py`: New tests covering basic math, math functions, and security exploits.
- Verified the fix with the new test suite, confirming that exploits are now blocked.

---
*PR created automatically by Jules for task [13270261390370740344](https://jules.google.com/task/13270261390370740344) started by @jayshah5696*